### PR TITLE
Add cliff boundary unit tests (1s before, exact, 1s after)

### DIFF
--- a/contracts/grant_contracts/src/test.rs
+++ b/contracts/grant_contracts/src/test.rs
@@ -168,6 +168,65 @@ fn test_timestamp_math_no_overflow() {
 }
 
 #[test]
+fn test_cliff_one_second_before() {
+    let env = Env::default();
+    let contract_id = env.register(GrantContract, ());
+    let client = GrantContractClient::new(&env, &contract_id);
+
+    let recipient = Address::generate(&env);
+    let total_amount = U256::from_u64(1000);
+    let duration = 100u64;
+
+    let start_time = env.ledger().timestamp();
+    client.initialize_grant(&recipient, &total_amount, &duration);
+
+    env.ledger().set_timestamp(start_time - 1);
+
+    let claimable = client.claimable_balance();
+    assert_eq!(claimable, U256::from_u64(0));
+}
+
+#[test]
+fn test_cliff_exact_second() {
+    let env = Env::default();
+    let contract_id = env.register(GrantContract, ());
+    let client = GrantContractClient::new(&env, &contract_id);
+
+    let recipient = Address::generate(&env);
+    let total_amount = U256::from_u64(1000);
+    let duration = 100u64;
+
+    let start_time = env.ledger().timestamp();
+    client.initialize_grant(&recipient, &total_amount, &duration);
+
+    env.ledger().set_timestamp(start_time);
+
+    let claimable = client.claimable_balance();
+    assert_eq!(claimable, U256::from_u64(0));
+}
+
+#[test]
+fn test_cliff_one_second_after() {
+    let env = Env::default();
+    let contract_id = env.register(GrantContract, ());
+    let client = GrantContractClient::new(&env, &contract_id);
+
+    let recipient = Address::generate(&env);
+    let total_amount = U256::from_u64(1000);
+    let duration = 100u64;
+
+    let start_time = env.ledger().timestamp();
+    client.initialize_grant(&recipient, &total_amount, &duration);
+
+    env.ledger().set_timestamp(start_time + 1);
+
+    let claimable = client.claimable_balance();
+    let expected = total_amount * U256::from_u64(1) / U256::from_u64(duration);
+    assert_eq!(claimable, expected);
+    assert!(claimable > U256::from_u64(0));
+}
+
+#[test]
 fn test_grant_info_function() {
     let env = Env::default();
     let contract_id = env.register(GrantContract, ());


### PR DESCRIPTION
## Summary
Adds unit tests for vesting cliff boundary conditions so `claimable_balance()` is correct and does not panic at the cliff.

## Changes
- **1 second before cliff:** `claimable_balance() == 0`
- **Exact cliff second:** `claimable_balance() == 0`
- **1 second after cliff:** `claimable_balance() == total_amount * 1 / duration` (> 0)

All three cases run without panic. Tests live in `contracts/grant_contracts/src/test.rs`.

closes #2 