### PR TITLE
Logic: implement multi-beneficiary split for group vesting schedules (#309)

### DIFF
--- a/contracts/vesting_contracts/src/lib.rs
+++ b/contracts/vesting_contracts/src/lib.rs
@@ -278,6 +278,7 @@ pub struct VestingScheduleLeaf {
 pub enum AdminAction {
     RevokeSchedule(u64, Address),
     AddBeneficiary(Address, ScheduleConfig),
+    AddGroupScheduleSplit(GroupScheduleConfig),
     RemoveAdmin(Address),
     AddAdmin(Address),
     UpdateQuorum(u32),
@@ -438,6 +439,26 @@ pub struct ScheduleConfig {
     pub keeper_fee: i128,
     pub is_revocable: bool,
     pub is_transferable: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BeneficiarySplit {
+    pub beneficiary: Address,
+    pub share_bps: u32, // 10000 = 100%
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupScheduleConfig {
+    pub beneficiaries: Vec<BeneficiarySplit>,
+    pub asset_basket: Vec<AssetAllocationEntry>,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub keeper_fee: i128,
+    pub is_revocable: bool,
+    pub is_transferable: bool,
+    pub step_duration: u64,
 }
 
 #[contractevent]
@@ -664,6 +685,9 @@ impl VestingContract {
                     0, // Default step_duration
                     true,
                 );
+            },
+            AdminAction::AddGroupScheduleSplit(cfg) => {
+                let _ids = Self::add_group_schedule_split_internal(&env, cfg);
             },
             AdminAction::GrantManagerRights(manager, asset, amount) => {
                 let pool = SubAdminPool {
@@ -1107,6 +1131,39 @@ impl VestingContract {
                 s.is_transferable,
                 0, // step_duration
                 true
+            );
+            ids.push_back(id);
+        }
+        ids
+    }
+
+    /// Create one group schedule and split it across multiple beneficiaries by basis points.
+    /// Uses deterministic integer math and remainder distribution so total amounts are conserved.
+    pub fn add_group_schedule_split(env: Env, config: GroupScheduleConfig) -> Vec<u64> {
+        Self::require_admin(&env);
+        if Self::multisig_active(&env) { panic!("Use AdminProposal for multisig"); }
+        Self::add_group_schedule_split_internal(&env, config)
+    }
+
+    fn add_group_schedule_split_internal(env: &Env, config: GroupScheduleConfig) -> Vec<u64> {
+        let total_amount = Self::validate_group_schedule_config(&config);
+        Self::require_deposited_tokens_for_batch(env, total_amount);
+        Self::reserve_admin_balance_for_batch(env, total_amount);
+
+        let mut ids = Vec::new(env);
+        for split in config.beneficiaries.iter() {
+            let split_basket = Self::build_split_basket(env, &config.asset_basket, &config.beneficiaries, &split.beneficiary);
+            let id = Self::create_vault_prefunded_internal(
+                env,
+                split.beneficiary,
+                split_basket,
+                config.start_time,
+                config.end_time,
+                config.keeper_fee,
+                config.is_revocable,
+                config.is_transferable,
+                config.step_duration,
+                true,
             );
             ids.push_back(id);
         }
@@ -3275,6 +3332,115 @@ impl VestingContract {
         total_amount
     }
 
+    fn validate_group_schedule_config(config: &GroupScheduleConfig) -> i128 {
+        if config.beneficiaries.is_empty() {
+            panic!("Empty beneficiary split");
+        }
+
+        let mut total_share_bps: u32 = 0;
+        for (i, split) in config.beneficiaries.iter().enumerate() {
+            if split.share_bps == 0 {
+                panic!("Beneficiary share must be greater than 0");
+            }
+
+            for j in (i + 1)..config.beneficiaries.len() {
+                let other = config.beneficiaries.get(j).unwrap();
+                if split.beneficiary == other.beneficiary {
+                    panic!("Duplicate beneficiary in split");
+                }
+            }
+
+            total_share_bps = total_share_bps
+                .checked_add(split.share_bps)
+                .expect("Split share overflow");
+        }
+
+        if total_share_bps != 10000 {
+            panic!("Beneficiary shares must sum to 10000");
+        }
+
+        Self::require_valid_duration(config.start_time, config.end_time);
+
+        let mut total_amount: i128 = 0;
+        for allocation in config.asset_basket.iter() {
+            if allocation.total_amount < 0 {
+                panic!("Invalid amount");
+            }
+            total_amount = total_amount
+                .checked_add(allocation.total_amount)
+                .expect("Group schedule amount overflow");
+        }
+
+        total_amount
+    }
+
+    fn build_split_basket(
+        env: &Env,
+        base_basket: &Vec<AssetAllocationEntry>,
+        splits: &Vec<BeneficiarySplit>,
+        beneficiary: &Address,
+    ) -> Vec<AssetAllocationEntry> {
+        let mut split_basket = Vec::new(env);
+
+        let beneficiary_index = Self::find_beneficiary_index(splits, beneficiary);
+        for allocation in base_basket.iter() {
+            let split_amounts = Self::split_amount_by_bps(env, allocation.total_amount, splits);
+            let beneficiary_amount = split_amounts.get(beneficiary_index).unwrap();
+
+            let split_allocation = AssetAllocationEntry {
+                asset_id: allocation.asset_id,
+                total_amount: beneficiary_amount,
+                released_amount: 0,
+                locked_amount: 0,
+                percentage: allocation.percentage,
+            };
+            split_basket.push_back(split_allocation);
+        }
+
+        split_basket
+    }
+
+    fn find_beneficiary_index(splits: &Vec<BeneficiarySplit>, beneficiary: &Address) -> u32 {
+        for (i, split) in splits.iter().enumerate() {
+            if split.beneficiary == *beneficiary {
+                return i.try_into().unwrap();
+            }
+        }
+        panic!("Beneficiary not found in split");
+    }
+
+    fn split_amount_by_bps(env: &Env, total_amount: i128, splits: &Vec<BeneficiarySplit>) -> Vec<i128> {
+        let mut amounts = Vec::new(env);
+        let mut distributed = 0i128;
+
+        for split in splits.iter() {
+            let product = total_amount
+                .checked_mul(split.share_bps as i128)
+                .expect("Split multiplication overflow");
+            let amount = product / 10000i128;
+            amounts.push_back(amount);
+            distributed = distributed
+                .checked_add(amount)
+                .expect("Split accumulation overflow");
+        }
+
+        let mut remainder = total_amount - distributed;
+        let split_count = amounts.len();
+        if split_count == 0 {
+            panic!("Empty beneficiary split");
+        }
+
+        let mut idx = 0u32;
+        while remainder > 0 {
+            let current = amounts.get(idx).unwrap();
+            amounts.set(idx, current + 1);
+            remainder -= 1;
+            idx = if idx + 1 == split_count { 0 } else { idx + 1 };
+        }
+
+        amounts
+    }
+
     fn add_user_vault_index(env: &Env, user: &Address, id: u64) {
         let mut vaults: Vec<u64> = env
             .storage()
@@ -5018,6 +5184,7 @@ impl VestingContract {
     // Private helper methods for legal document integration
 
 // Redefinition removed
+}
 
 #[cfg(test)]
 mod test;

--- a/contracts/vesting_contracts/src/test.rs
+++ b/contracts/vesting_contracts/src/test.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BatchCreateData, VestingContract, VestingContractClient,
-    AssetAllocationEntry,
+    AssetAllocationEntry, BeneficiarySplit, GroupScheduleConfig,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -159,6 +159,188 @@ fn test_batch_operations() {
     assert_eq!(ids.len(), 2);
     assert_eq!(ids.get(0).unwrap(), 1);
     assert_eq!(ids.get(1).unwrap(), 2);
+}
+
+#[test]
+fn test_add_group_schedule_split_happy_path() {
+    let (env, admin, client, token_address, _) = setup();
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+
+    // Prefund contract balance so batch-style checks pass.
+    let _prefund_vault = client.create_vault_full(
+        &admin,
+        &1000i128,
+        &now,
+        &(now + 1000),
+        &0i128,
+        &true,
+        &true,
+        &0u64,
+    );
+
+    let basket = vec![&env, AssetAllocationEntry {
+        asset_id: token_address,
+        total_amount: 1000,
+        released_amount: 0,
+        locked_amount: 0,
+        percentage: 10000,
+    }];
+
+    let splits = vec![
+        &env,
+        BeneficiarySplit { beneficiary: b1.clone(), share_bps: 6000 },
+        BeneficiarySplit { beneficiary: b2.clone(), share_bps: 4000 },
+    ];
+
+    let cfg = GroupScheduleConfig {
+        beneficiaries: splits,
+        asset_basket: basket,
+        start_time: now,
+        end_time: now + 1000,
+        keeper_fee: 0,
+        is_revocable: true,
+        is_transferable: false,
+        step_duration: 0,
+    };
+
+    let ids = client.add_group_schedule_split(&cfg);
+    assert_eq!(ids.len(), 2);
+
+    let v1 = client.get_vault(&ids.get(0).unwrap());
+    let v2 = client.get_vault(&ids.get(1).unwrap());
+
+    assert_eq!(v1.owner, b1);
+    assert_eq!(v1.allocations.get(0).unwrap().total_amount, 600);
+    assert_eq!(v2.owner, b2);
+    assert_eq!(v2.allocations.get(0).unwrap().total_amount, 400);
+}
+
+#[test]
+fn test_add_group_schedule_split_preserves_total_with_rounding() {
+    let (env, admin, client, token_address, _) = setup();
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+
+    let _prefund_vault = client.create_vault_full(
+        &admin,
+        &5i128,
+        &now,
+        &(now + 1000),
+        &0i128,
+        &true,
+        &true,
+        &0u64,
+    );
+
+    let basket = vec![&env, AssetAllocationEntry {
+        asset_id: token_address,
+        total_amount: 5,
+        released_amount: 0,
+        locked_amount: 0,
+        percentage: 10000,
+    }];
+
+    let splits = vec![
+        &env,
+        BeneficiarySplit { beneficiary: b1, share_bps: 5000 },
+        BeneficiarySplit { beneficiary: b2, share_bps: 5000 },
+    ];
+
+    let cfg = GroupScheduleConfig {
+        beneficiaries: splits,
+        asset_basket: basket,
+        start_time: now,
+        end_time: now + 1000,
+        keeper_fee: 0,
+        is_revocable: true,
+        is_transferable: false,
+        step_duration: 0,
+    };
+
+    let ids = client.add_group_schedule_split(&cfg);
+    let v1 = client.get_vault(&ids.get(0).unwrap());
+    let v2 = client.get_vault(&ids.get(1).unwrap());
+
+    // Deterministic remainder handling: first beneficiary receives the extra unit.
+    assert_eq!(v1.allocations.get(0).unwrap().total_amount, 3);
+    assert_eq!(v2.allocations.get(0).unwrap().total_amount, 2);
+
+    let total = v1.allocations.get(0).unwrap().total_amount + v2.allocations.get(0).unwrap().total_amount;
+    assert_eq!(total, 5);
+}
+
+#[test]
+#[should_panic(expected = "Beneficiary shares must sum to 10000")]
+fn test_add_group_schedule_split_rejects_invalid_share_total() {
+    let (env, _admin, client, token_address, _) = setup();
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+
+    let basket = vec![&env, AssetAllocationEntry {
+        asset_id: token_address,
+        total_amount: 1000,
+        released_amount: 0,
+        locked_amount: 0,
+        percentage: 10000,
+    }];
+
+    let splits = vec![
+        &env,
+        BeneficiarySplit { beneficiary: b1, share_bps: 7000 },
+        BeneficiarySplit { beneficiary: b2, share_bps: 2000 },
+    ];
+
+    let cfg = GroupScheduleConfig {
+        beneficiaries: splits,
+        asset_basket: basket,
+        start_time: now,
+        end_time: now + 1000,
+        keeper_fee: 0,
+        is_revocable: true,
+        is_transferable: false,
+        step_duration: 0,
+    };
+
+    let _ = client.add_group_schedule_split(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Duplicate beneficiary in split")]
+fn test_add_group_schedule_split_rejects_duplicate_beneficiary() {
+    let (env, _admin, client, token_address, _) = setup();
+    let b1 = Address::generate(&env);
+    let now = env.ledger().timestamp();
+
+    let basket = vec![&env, AssetAllocationEntry {
+        asset_id: token_address,
+        total_amount: 1000,
+        released_amount: 0,
+        locked_amount: 0,
+        percentage: 10000,
+    }];
+
+    let splits = vec![
+        &env,
+        BeneficiarySplit { beneficiary: b1.clone(), share_bps: 5000 },
+        BeneficiarySplit { beneficiary: b1, share_bps: 5000 },
+    ];
+
+    let cfg = GroupScheduleConfig {
+        beneficiaries: splits,
+        asset_basket: basket,
+        start_time: now,
+        end_time: now + 1000,
+        keeper_fee: 0,
+        is_revocable: true,
+        is_transferable: false,
+        step_duration: 0,
+    };
+
+    let _ = client.add_group_schedule_split(&cfg);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR implements the **Multi-Beneficiary Split** logic for group vesting schedules.

### What's included
- Added a new flow to split a single group schedule across multiple beneficiaries.
- Added new config types:
  - `BeneficiarySplit`
  - `GroupScheduleConfig`
- Added a new contract entrypoint:
  - `add_group_schedule_split`
- Implemented deterministic integer split logic with safe remainder distribution so total token amounts stay exact.
- Added strict validation for safety and correctness:
  - split list must not be empty
  - beneficiaries must be unique
  - each share must be greater than 0
  - total shares must equal `10000` bps
  - schedule duration must be valid
  - asset amounts must be non-negative
- Wired the multisig/admin path through:
  - `AdminAction::AddGroupScheduleSplit`

## Tests

Added coverage for:
- happy path split behavior
- precision/rounding remainder handling
- invalid share-total rejection
- duplicate-beneficiary rejection

## Notes

- Full local test execution is currently blocked by pre-existing repo-wide compile issues unrelated to this change.
- Scope of this PR is intentionally limited to issue #309 logic and tests.

Closes #309